### PR TITLE
Python 3.4 needs expansion of kwargs always last in function calls

### DIFF
--- a/synpurge
+++ b/synpurge
@@ -91,8 +91,8 @@ class Config(object):
         ini = ConfigParser(default_section=None, interpolation=None)
         ini.read(path)
         rooms = set()
-        cfg = Config(**ini["synpurge"], rooms=rooms)
-        [rooms.add(RoomConfig(**ini[s], name=s, config=cfg))
+        cfg = Config(rooms=rooms, **ini["synpurge"])
+        [rooms.add(RoomConfig(name=s, config=cfg, **ini[s]))
             for s in ini.sections() if s != "synpurge"]
         return cfg
 


### PR DESCRIPTION
This makes it possible to run Synpurge with Python 3.4