### PR TITLE
Added experimental concurrent reindex command

### DIFF
--- a/synpurge/cli.py
+++ b/synpurge/cli.py
@@ -115,6 +115,33 @@ def cleanup(path: "configuration file",
 
 
 @cmd
+def reindex(path: "configuration file",
+            concurrent: "enable enable concurrent reindexing" = False,
+            debug: "enable debugging output" = False,
+            verbose: "enable verbose operation" = False):
+    """Reindex the database."""
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+    elif verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    from . import config, pg
+    try:
+        c = config.load(path)
+    except Exception as e:
+        raise SystemExit("Error loading configuration: {!s}".format(e))
+
+    if not c.database:
+        raise SystemExit("No database configured")
+
+    pgdb = pg.open(c.database)
+    log.debug("Using PostgreSQL: %r", pgdb)
+    if concurrent:
+        pgdb.reindex_concurrent()
+    else:
+        pgdb.reindex()
+
+@cmd
 def purge(path: "configuration file",
           debug: "enable debugging output" = False,
           verbose: "enable verbose operation" = False,

--- a/synpurge/pglib/libsynapse.sql
+++ b/synpurge/pglib/libsynapse.sql
@@ -36,3 +36,17 @@ WHERE r.room_id = $1
   AND r.room_id = a.room_id
 GROUP BY
     r.room_id;
+
+[table_indexes]
+SELECT 
+    idx.relname AS index, 
+	pg_get_indexdef(idx.oid)||';' AS definition, 
+	ind.indisclustered AS clustered 
+FROM  pg_index ind
+    JOIN pg_class idx ON idx.oid = ind.indexrelid
+    JOIN pg_class tbl ON tbl.oid = ind.indrelid
+    LEFT JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+WHERE tbl.relname = $1
+    AND ind.indisvalid
+    AND ind.indisready
+


### PR DESCRIPTION
**Experimental**

Added a new function in the Database class to perform the
reindexation of the huge tables. This fuctions creates a concurrent
secondary index using CREATE INDEX CONCURRENTLY. When the new index
is ready, it performs the DROP of the older index and replaces it
with the newest.

This operation has 2 advantages respect the reindex based on the
REINDEX TABLE operation:

* It doesn't lock the table so the service is not affected
* It is much faster than the REINDEX

In the other hand:

* Creation of the new INDEX could fail (catched as exepction)
* More disk usage is required because we are duplicating the index

Related: #10