### PR TITLE
Make room info hashable in order for frozenset to run properly

### DIFF
--- a/synpurge/purger.py
+++ b/synpurge/purger.py
@@ -39,7 +39,7 @@ class DuplicateRoomId(Exception):
         return "\n".join(lines)
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, hash=True)
 class PurgeInfo(object):
     room_id = attr.ib(validator=vv.instance_of(str))
     config = attr.ib(validator=vv.instance_of(config.Room))


### PR DESCRIPTION
Python attrs version 17 introduced changes to the way object hashes work. Thus, this fix forces the library to generate a hash function for our objects.

Fixes #17 and #15 